### PR TITLE
fix(#6): Headers now working correctly.

### DIFF
--- a/src/env/headers.ts
+++ b/src/env/headers.ts
@@ -1,4 +1,4 @@
-import type { TBunHeaders } from '../elysia-bun-types.js';
+import type { TBunHeaders } from "../elysia-bun-types.js";
 
 // @ts-expect-error
 globalThis.Headers = class Headers
@@ -17,12 +17,14 @@ globalThis.Headers = class Headers
 };
 
 globalThis.Request = class Request extends globalThis.Request {
+  #headers = new globalThis.Headers(
+    // @ts-expect-error
+    super.headers
+  );
+
   // @ts-expect-error
   get headers() {
-    return new globalThis.Headers(
-      // @ts-expect-error
-      super.headers
-    );
+    return this.#headers;
   }
 };
 
@@ -31,11 +33,13 @@ globalThis.Response = class Response extends globalThis.Response {
     super(init?.status === 204 ? null : body, init);
   }
 
+  #headers = new globalThis.Headers(
+    // @ts-expect-error
+    super.headers
+  );
+
   // @ts-expect-error
   get headers() {
-    return new globalThis.Headers(
-      // @ts-expect-error
-      super.headers
-    );
+    return this.#headers;
   }
 };


### PR DESCRIPTION
Headers are should be persisted. Before each time we wanted to add a header, it would create a new header object and then discard it when we tried to later add something to it.

It would also return a new header everywhere because calling `request.header` would construct a new one.

I'm not sure if this breaks anything else, but from my testing on my app it seems to be working fine.

Fixes: #6